### PR TITLE
Better css filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Options:
   -h, --help                 output usage information
   -V, --version              output the version number
   -f, --functional           create a functional component
+  -c, --css-extension [ext   specify the extension of generated css files
   -d, --directory [dir]      specify a directory for the component
 ```
 
@@ -20,6 +21,7 @@ Project specific settings can be added to the `package.json` file under the `cra
 ```json
 "craGenerate": {
   "fileFormat": "paramCase",
+  "cssExtension": "scss",
   "directory": "widgets"
 }
 ```
@@ -30,6 +32,7 @@ Project specific settings can be added to the `package.json` file under the `cra
 | fileFormat      | `string`  | "pascalCase"  | One of: camelCase, constantCase, headerCase, paramCase, pascalCase or snakeCase. |
 | componentFormat | `string`  | "pascalCase"  | One of: camelCase, constantCase, headerCase, paramCase, pascalCase or snakeCase. |
 | typeCheck       | `undefined|string` | `undefined` | Can be set explicitly to "flow".                                                 |
+| cssExtension    | `string`  | "css"         | File extensions, with or without a dot                                       |
 
 ## License
 

--- a/config.js
+++ b/config.js
@@ -12,6 +12,7 @@ try {
 const defaultOptions =  {
   directory: 'components',
   typeCheck: fs.existsSync(path.join(process.cwd(), '.flowconfig')) && 'flow',
+  cssExtension: 'css',
   fileFormat: 'pascalCase',
   componentFormat: 'pascalCase',
 }
@@ -20,6 +21,10 @@ module.exports = function (program) {
   const config = Object.assign({}, defaultOptions, pkg.craGenerate || {})
 
   config.isFunctional = Boolean(program.functional)
+
+  if (program.cssExtension) {
+    config.cssExtension = program.cssExtension
+  }
 
   if (program.typeCheck) {
     config.typeCheck = program.typeCheck

--- a/generate.js
+++ b/generate.js
@@ -24,8 +24,11 @@ function template(file) {
   }
 }
 
-function save(componentName, fileName, filePath, content) {
-  const contents = content.replace(/\$Name\$/g, componentName).replace(/\$name\$/g, fileName)
+function save(componentName, fileName, filePath, cssExtension, content) {
+  const contents = content
+    .replace(/\$Name\$/g, componentName)
+    .replace(/\$name\$/g, fileName)
+    .replace(/\$css-ext\$/g, cssExtension)
   fs.writeFile(filePath, contents, 'utf8')
 }
 
@@ -98,6 +101,7 @@ function generate(component, options) {
     template(options.isFunctional ? 'stateless.js' : 'stateful.js'),
   ]
   const styleFiles = [template('styles.css')]
+  const cssExtension = options.cssExtension.replace(/^\./, '')
 
   scriptFiles.forEach(script => {
     const { name } = path.parse(script.filePath)
@@ -105,12 +109,12 @@ function generate(component, options) {
     const filePath = path.join(componentPath,
       `${name === 'index' ? 'index' : fileName}.js`
     )
-    save(componentName, fileName, filePath, content)
+    save(componentName, fileName, filePath, cssExtension, content)
   })
 
   styleFiles.forEach(style => {
-    const filePath = path.join(componentPath, 'styles.css')
-    save(componentName, fileName, filePath, style.content)
+    const filePath = path.join(componentPath, `${fileName}.${cssExtension}`)
+    save(componentName, fileName, filePath, cssExtension, style.content)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const program = commander
   .version(version)
   .option('-f, --functional', 'create a functional component')
   .option('-t, --type-check [system]', 'add @flow comment to script files')
+  .option('-c, --css-extension [extension]', 'changes the extension of generated css files')
   .option('-d, --directory [dir]', 'specify a directory for the component')
   .arguments('<component>')
   .action((c) => component = c)

--- a/templates/component/stateful.js
+++ b/templates/component/stateful.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import './styles.css'
+import './$name$.$css-ext$'
 
 class $Name$ extends Component {
   state = {}

--- a/templates/component/stateless.js
+++ b/templates/component/stateless.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import './styles.css'
+import './$name$.$css-ext$'
 
 const $Name$ = ({}) => (
   <div className="$Name$"></div>


### PR DESCRIPTION
Use the component name, like create-react-app.
Configuration of the file extension.

Fixes #3  and #4 