### PR TITLE
Always reference .css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cra-generate",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Scaffold react components",
   "main": "index.js",
   "repository": "rthor/cra-generate",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cra-generate",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Scaffold react components",
   "main": "index.js",
   "repository": "rthor/cra-generate",

--- a/templates/template.javascript.js
+++ b/templates/template.javascript.js
@@ -35,7 +35,7 @@ it('renders without crashing', () => {
     [`${fileName}.js`]: isFunctional
       ? `
 import React from 'react'${semiColon}
-import './${fileName}.${cssExtension}'${semiColon}
+import './${fileName}.css'${semiColon}
 
 const ${componentName} = ({}) => (
   <div className="${componentName}"></div>
@@ -46,7 +46,7 @@ export default ${componentName}${semiColon}
   `
       : `
 import React, { Component } from 'react'${semiColon}
-import './${fileName}.${cssExtension}'${semiColon}
+import './${fileName}.css'${semiColon}
 
 class ${componentName} extends Component {
   state = {}${semiColon}


### PR DESCRIPTION
Hello, thank you for this handy project! I found a small bug that I'd like to provide a fix for.

I set up Sass for my CRA project [per the standard CRA documentation](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-a-css-preprocessor-sass-less-etc), which necessitates `import`ing `.css` files instead of `.scss` from the `.js` file. This PR changes the generator to reference the correct file.